### PR TITLE
fail-fast

### DIFF
--- a/playbook/baseline.yml
+++ b/playbook/baseline.yml
@@ -3,6 +3,7 @@
 - hosts: all
   become: yes
   gather_facts: no
+  any_errors_fatal: true
   tasks:
     - name: check for python2
       stat:


### PR DESCRIPTION
Fail when python installation fails on **any** host from inventory as python is crucial dependency.